### PR TITLE
Allow to configure php extensions on the build action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: "The PHP version for actions/setup-php"
     required: false
     default: 'latest'
+  php_extensions:
+    description: "The extensions parameter for actions/setup-php"
+    required: false
+    default: 'mbstring'
   composer_version:
     description: "The Composer version for actions/setup-php"
     required: false
@@ -33,6 +37,7 @@ runs:
       with:
         php-version: "${{ inputs.php_version }}"
         tools: "composer:${{ inputs.composer_version }}"
+        extensions: "${{ inputs.php_extensions }}"
 
     - name: Get composer store directory
       if: ${{ hashFiles( '**/composer.json' ) != '' }}


### PR DESCRIPTION
Defaulting to a relatively safe default, currently used in the composer-update reusable workflow
